### PR TITLE
Update rake task and travis yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,8 @@ sudo: false
 language: ruby
 rvm:
   - 2.3.1
-before_install:
-  - rvm @default,@global do gem uninstall bundler -x
-  - gem install bundler --version '~> 1.13.0'
-  - bundle --version
-before_script:
-  - sh -e /etc/init.d/xvfb start
-  - export DISPLAY=:99.0
-  - bundle exec rake test_app
 script:
-  - bundle exec rspec spec
+  - bundle exec rake
 env:
   matrix:
     - SOLIDUS_BRANCH=v1.0 DB=postgres

--- a/Rakefile
+++ b/Rakefile
@@ -6,10 +6,17 @@ require 'spree/testing_support/common_rake'
 
 RSpec::Core::RakeTask.new
 
-task default: :spec
+task default: %i(first_run spec)
 
 desc 'Generates a dummy app for testing'
 task :test_app do
   ENV['LIB_NAME'] = 'solidus_wishlist'
   Rake::Task['common:test_app'].invoke
+end
+
+task :first_run do
+  if Dir['spec/dummy'].empty?
+    Rake::Task[:test_app].invoke
+    Dir.chdir('../../')
+  end
 end


### PR DESCRIPTION
add task to build test_app with default task when is needed, so can remove travis `before_script` and remove `before_install` since travis is using latest stable bundler