### PR TITLE
Add Authentication to Wishlists Controller

### DIFF
--- a/app/controllers/spree/wishlists_controller.rb
+++ b/app/controllers/spree/wishlists_controller.rb
@@ -59,5 +59,6 @@ class Spree::WishlistsController < Spree::StoreController
   # Isolate this method so it can be overwritten
   def find_wishlist
     @wishlist = Spree::Wishlist.find_by_access_hash!(params[:id])
+    authorize! params[:action].to_sym, @wishlist
   end
 end

--- a/spec/features/spree/wishlist_spec.rb
+++ b/spec/features/spree/wishlist_spec.rb
@@ -144,6 +144,36 @@ RSpec.feature 'Wishlist', :js do
       end
     end
 
+    context 'when logged in', type: :controller do
+      given(:user_1)      { create(:user) }
+      given(:user_2)      { create(:user) }
+
+      background do
+        sign_in_as! user_1
+      end
+
+      scenario 'visit own private wishlist' do
+        wishlist.is_private = true
+        wishlist.user = user_1
+        wishlist.save
+
+        visit spree.wishlist_path(wishlist)
+
+        expect(current_path).to match(spree.wishlist_path(wishlist))
+        expect(page).to have_content wishlist.name
+      end
+
+      scenario 'visit other private wishlist' do
+        wishlist.is_private = true
+        wishlist.user = user_2
+        wishlist.save
+
+        visit spree.wishlist_path(wishlist)
+
+        expect(current_path).not_to match(spree.wishlist_path(wishlist))
+        expect(page).not_to have_content wishlist.name
+      end
+    end
   end
 
   private

--- a/spec/features/spree/wishlist_spec.rb
+++ b/spec/features/spree/wishlist_spec.rb
@@ -119,6 +119,32 @@ RSpec.feature 'Wishlist', :js do
       end
     end
   end
+  
+  context 'wishlist privacy settings', type: :controller do
+    given(:wishlist) { create(:wishlist) }
+
+    context 'when logged out' do
+
+      scenario 'visit a private wishlist' do
+        wishlist.update_attributes(is_private: true)
+
+        visit spree.wishlist_path(wishlist)
+
+        expect(current_path).not_to match(spree.wishlist_path(wishlist))
+        expect(page).not_to have_content wishlist.name
+      end
+
+      scenario 'visit a public wishlist' do
+        wishlist.update_attributes(is_private: false)
+
+        visit spree.wishlist_path(wishlist)
+
+        expect(current_path).to match(spree.wishlist_path(wishlist))
+        expect(page).to have_content wishlist.name
+      end
+    end
+
+  end
 
   private
 


### PR DESCRIPTION
As discussed in https://github.com/boomerdigital/solidus_wishlist/issues/12, there were existing authentication issues where private wishlists were still viewable by both logged-out users and by logged-in users who were not the owner of the private wishlist.

This PR adds a pair of failing specs and a (one-line) fix to add authentication to the controller. All specs are now green.