### PR TITLE
Do not try to display discarded products/variants.

### DIFF
--- a/app/models/spree/wishlist.rb
+++ b/app/models/spree/wishlist.rb
@@ -1,6 +1,9 @@
 class Spree::Wishlist < ActiveRecord::Base
   belongs_to :user, class_name: 'Spree::User'
   has_many :wished_products, dependent: :destroy
+  has_many :visible_wished_products,
+    -> { joins(:variant).where(spree_variants: {deleted_at: nil}) },
+    class_name: "Spree::WishedProduct"
   before_create :set_access_hash
 
   validates :name, presence: true

--- a/app/views/spree/wishlists/show.html.erb
+++ b/app/views/spree/wishlists/show.html.erb
@@ -23,8 +23,8 @@
     </tr>
   </thead>
   <tbody id="line_items">
-  <% if @wishlist.wished_products.size > 0 %>
-    <% @wishlist.wished_products.each do |wish|
+  <% if @wishlist.visible_wished_products.size > 0 %>
+    <% @wishlist.visible_wished_products.each do |wish|
         variant = wish.variant
         product = variant.product %>
     <tr class="<%= cycle('', 'alt') %>">

--- a/spec/features/spree/wishlist_spec.rb
+++ b/spec/features/spree/wishlist_spec.rb
@@ -47,6 +47,34 @@ RSpec.feature 'Wishlist', :js do
       sign_in_as! user
     end
 
+    context 'show', :focus do
+      background do
+        wishlist.wished_products << Spree::WishedProduct.new(variant: product.master)
+      end
+
+      context 'wishlist has a current product' do
+        scenario 'it displays the product' do
+          visit spree.account_path
+          click_link wishlist.name
+
+          expect(page).to have_content(product.name)
+        end
+      end
+
+      context 'wishlist has a discarded product' do
+        background do
+          product.discard
+        end
+
+        scenario 'it does not display the product' do
+          visit spree.account_path
+          click_link wishlist.name
+
+          expect(page).to_not have_content(product.name)
+        end
+      end
+    end
+
     context 'edit' do
       scenario 'edit a wishlists name' do
         visit_edit_wishlist


### PR DESCRIPTION
First of all thanks for the wonderful plugin. We have been evaluating it and liked it a lot.

But we found one issue: When we delete a product in the admin backend that is still stored in a wishlist, there is an exception when trying to display that wishlist.

The reason is, that the product is not actually destroyed, but there is a `deleted_at` timestamp set. And there is a default scope for both `Spree::Product` and `Spree::Variant` that only queries records where `deleted_at` is `NULL`. That is why the variant stored in the wishlist can no longer be accessed.

The changes in this PR fix the issue for us. Of course, if you prefer another way to fix it, that is totally fine as well.

Thanks again and keep up the good work!